### PR TITLE
added parens around critical percent conditional to decrease ambiguity

### DIFF
--- a/src/norm.cpp
+++ b/src/norm.cpp
@@ -224,7 +224,7 @@ int main(int argc, char *argv[])
         return 1;
     }
 
-    if (critPercent != DEFAULT_CRIT_PERCENT && critPercent <= 0 || critPercent >= 1)
+    if (critPercent != DEFAULT_CRIT_PERCENT && (critPercent <= 0 || critPercent >= 1))
     {
         cerr << "ERROR: Critical percentile must be in (0,1).\n";
         return 1;
@@ -343,7 +343,7 @@ int main(int argc, char *argv[])
 
         double upperCutoff, lowerCutoff;
 
-        if (critPercent != DEFAULT_CRIT_PERCENT && critPercent <= 0 || critPercent >= 1)
+        if (critPercent != DEFAULT_CRIT_PERCENT && (critPercent <= 0 || critPercent >= 1))
         {
             upperCutoff = gsl_stats_quantile_from_sorted_data (score, 1, totalLoci, 1 - critPercent / 2.0 );
             lowerCutoff = gsl_stats_quantile_from_sorted_data (score, 1, totalLoci, critPercent / 2.0);
@@ -429,7 +429,7 @@ int main(int argc, char *argv[])
 
         double upperCutoff, lowerCutoff;
 
-        if (critPercent != DEFAULT_CRIT_PERCENT && critPercent <= 0 || critPercent >= 1)
+        if (critPercent != DEFAULT_CRIT_PERCENT && (critPercent <= 0 || critPercent >= 1))
         {
             upperCutoff = gsl_stats_quantile_from_sorted_data (score, 1, totalLoci, 1 - critPercent / 2.0 );
             lowerCutoff = gsl_stats_quantile_from_sorted_data (score, 1, totalLoci, critPercent / 2.0);


### PR DESCRIPTION
added parentheses around critical percent conditional to decrease
ambiguity of the conditions being checked and to also squelch warnings
when compiled under Apple’s g++ 4.2.1