### PR TITLE
Added the ”—ihs-detail" parameter to optionally write full iHH information for each locus of an iHS calculation: left and right integrals for ancestral and derived iHH.

### DIFF
--- a/src/selscan-main.cpp
+++ b/src/selscan-main.cpp
@@ -122,6 +122,10 @@ const string ARG_IHS = "--ihs";
 const bool DEFAULT_IHS = false;
 const string HELP_IHS = "Set this flag to calculate iHS.";
 
+const string ARG_IHS_DETAILED = "--ihs-detail";
+const bool DEFAULT_IHS_DETAILED = false;
+const string HELP_IHS_DETAILED = "Set this flag to write out left and right iHH scores for '1' and '0' in addition to iHS.";
+
 const string ARG_SOFT = "--soft";
 const bool DEFAULT_SOFT = false;
 const string HELP_SOFT = "Calculate the EHH1K decay for soft sweep detection.";
@@ -197,6 +201,10 @@ struct work_order_t
     double (*calc)(map<string, int> &, int, bool);
 
     double *ihs;
+    double *ihhDerivedLeft;
+    double *ihhDerivedRight;
+    double *ihhAncestralLeft;
+    double *ihhAncestralRight;
     double *freq;
 
     double *ihh1;
@@ -263,6 +271,7 @@ int main(int argc, char *argv[])
     params.addFlag(ARG_MAX_GAP, DEFAULT_MAX_GAP, "", HELP_MAX_GAP);
     params.addFlag(ARG_GAP_SCALE, DEFAULT_GAP_SCALE, "", HELP_GAP_SCALE);
     params.addFlag(ARG_IHS, DEFAULT_IHS, "", HELP_IHS);
+    params.addFlag(ARG_IHS_DETAILED, DEFAULT_IHS_DETAILED, "", HELP_IHS_DETAILED);
     params.addFlag(ARG_SOFT, DEFAULT_SOFT, "SILENT", HELP_SOFT);
     params.addFlag(ARG_XP, DEFAULT_XP, "", HELP_XP);
     params.addFlag(ARG_ALT, DEFAULT_ALT, "", HELP_ALT);
@@ -322,6 +331,7 @@ int main(int argc, char *argv[])
 
     bool ALT = params.getBoolFlag(ARG_ALT);
     bool CALC_IHS = params.getBoolFlag(ARG_IHS);
+    bool WRITE_DETAILED_IHS = params.getBoolFlag(ARG_IHS_DETAILED);
     bool CALC_XP = params.getBoolFlag(ARG_XP);
     bool CALC_SOFT = params.getBoolFlag(ARG_SOFT);
     bool SINGLE_EHH = false;
@@ -341,6 +351,11 @@ int main(int argc, char *argv[])
     if (CALC_IHS + CALC_XP + SINGLE_EHH + CALC_PI != 1)
     {
         cerr << "ERROR: Must specify one and only one of EHH (" << ARG_EHH << "), iHS (" << ARG_IHS << "), XP-EHH (" << ARG_XP << "), PI (" << ARG_PI << ")\n";
+        return 1;
+    }
+
+    if (WRITE_DETAILED_IHS && !CALC_IHS){
+        cerr << "ERROR: The flag " << ARG_IHS_DETAILED << " must be used with " << ARG_IHS << " \n";
         return 1;
     }
 
@@ -562,6 +577,7 @@ int main(int argc, char *argv[])
     Bar pbar;
 
     double *ihs, *ihh1, *ihh2;
+    double *ihhDerivedLeft, *ihhDerivedRight, *ihhAncestralLeft, *ihhAncestralRight;
     double *freq, *freq1, *freq2;
 
     if (mapData->nloci < numThreads)
@@ -825,6 +841,11 @@ int main(int argc, char *argv[])
         ihh2 = new double[mapData->nloci];
         ihs = new double[hapData->nloci];
 
+        ihhDerivedLeft = new double[hapData->nloci];
+        ihhDerivedRight = new double[hapData->nloci];
+        ihhAncestralLeft = new double[hapData->nloci];
+        ihhAncestralRight = new double[hapData->nloci];
+
         barInit(pbar, mapData->nloci, 78);
 
         cerr << "Starting iHS calculations with alt flag ";
@@ -837,17 +858,21 @@ int main(int argc, char *argv[])
         for (int i = 0; i < numThreads; i++)
         {
             order = new work_order_t;
-            order->id = i;
-            order->hapData = hapData;
-            order->mapData = mapData;
-            order->ihh1 = ihh1;
-            order->ihh2 = ihh2;
-            order->ihs = ihs;
-            order->freq = freq;
-            order->flog = &flog;
-            order->bar = &pbar;
-            order->params = &params;
-            order->calc = &calculateHomozygosity;
+            order->id                = i;
+            order->hapData           = hapData;
+            order->mapData           = mapData;
+            order->ihh1              = ihh1;
+            order->ihh2              = ihh2;
+            order->ihs               = ihs;
+            order->ihhDerivedLeft    = ihhDerivedLeft;
+            order->ihhDerivedRight   = ihhDerivedRight;
+            order->ihhAncestralLeft  = ihhAncestralLeft;
+            order->ihhAncestralRight = ihhAncestralRight;
+            order->freq              = freq;
+            order->flog              = &flog;
+            order->bar               = &pbar;
+            order->params            = &params;
+            order->calc              = &calculateHomozygosity;
 
             pthread_create(&(peer[i]),
                            NULL,
@@ -873,7 +898,18 @@ int main(int argc, char *argv[])
                      << freq[i] << "\t"
                      << ihh1[i] << "\t"
                      << ihh2[i] << "\t"
-                     << ihs[i] << endl;
+                     << ihs[i];
+                if (!WRITE_DETAILED_IHS) 
+                {
+                    fout << endl;
+                } else 
+                {
+                    fout << "\t"
+                         << ihhDerivedLeft[i]    << "\t"
+                         << ihhDerivedRight[i]   << "\t"
+                         << ihhAncestralLeft[i]  << "\t"
+                         << ihhAncestralRight[i] << endl;
+                }
             }
         }
     }
@@ -1695,6 +1731,10 @@ void calc_ihs(void *order)
     double *ihs = p->ihs;
     double *ihh1 = p->ihh1;
     double *ihh2 = p->ihh2;
+    double *ihhDerivedLeft    = p->ihhDerivedLeft;
+    double *ihhDerivedRight   = p->ihhDerivedRight;
+    double *ihhAncestralLeft  = p->ihhAncestralLeft;
+    double *ihhAncestralRight = p->ihhAncestralRight;
     double *freq = p->freq;
     ofstream *flog = p->flog;
     Bar *pbar = p->bar;
@@ -1726,6 +1766,10 @@ void calc_ihs(void *order)
         //freq[locus] = MISSING;
         ihh1[locus] = MISSING;
         ihh2[locus] = MISSING;
+        ihhDerivedLeft[locus]    = MISSING;
+        ihhDerivedRight[locus]   = MISSING;
+        ihhAncestralLeft[locus]  = MISSING;
+        ihhAncestralRight[locus] = MISSING;
         bool skipLocus = 0;
         //If the focal snp has MAF < MAF, then skip this locus
         if (freq[locus] < MAF || freq[locus] > 1 - MAF)
@@ -1748,6 +1792,12 @@ void calc_ihs(void *order)
         int nextLocus = locus - 1;
         double derived_ihh = 0;
         double ancestral_ihh = 0;
+
+        double derived_ihh_left    = 0;
+        double ancestral_ihh_left  = 0;
+        double derived_ihh_right   = 0;
+        double ancestral_ihh_right = 0;    
+
         //double derivedCount = 0;
         //A list of all the haplotypes
         //Starts with just the focal snp and grows outward
@@ -1860,6 +1910,9 @@ void calc_ihs(void *order)
             continue;
         }
 
+        derived_ihh_left   = derived_ihh;
+        ancestral_ihh_left = ancestral_ihh;
+
         //calculate EHH to the right
         current_derived_ehh = 1;
         current_ancestral_ehh = 1;
@@ -1965,6 +2018,9 @@ void calc_ihs(void *order)
 
         }
 
+        derived_ihh_right   = derived_ihh   - derived_ihh_left;
+        ancestral_ihh_right = ancestral_ihh - ancestral_ihh_left;
+
         delete [] haplotypeList;
 
         if (skipLocus == 1)
@@ -1979,6 +2035,10 @@ void calc_ihs(void *order)
             ihh1[locus] = derived_ihh;
             ihh2[locus] = ancestral_ihh;
             ihs[locus] = log(derived_ihh / ancestral_ihh);
+            ihhDerivedLeft[locus]    = derived_ihh_left;
+            ihhDerivedRight[locus]   = derived_ihh_right;
+            ihhAncestralLeft[locus]  = ancestral_ihh_left;
+            ihhAncestralRight[locus] = ancestral_ihh_right;
             //freq[locus] = double(derivedCount) / double(nhaps);
         }
     }


### PR DESCRIPTION
To fulfill issue #12, I've added the `--ihs-detail` parameter which, when provided as an adjunct to `--ihs`, will cause selscan to write out four additional columns to the output file of iHS calculations (in order): derived_ihh_left, derived_ihh_right, ancestral_ihh_left, and ancestral_ihh_right.

An example file row follows, with header added for clarity.

```
locus           phys-pos        1_freq          ihh_1           ihh_0           ihs             derived_ihh_left     derived_ihh_right    ancestral_ihh_left      ancestral_ihh_right

16133705        16133705        0.873626        0.0961264       0.105545        -0.0934761      0.0505176             0.0456087           0.0539295               0.0516158
```

From these values we can calculate iHS, but it is preserved in the output for convenience. Having left and right integral information may assist certain machine learning models that gain information from iHH asymmetry.