### PR TITLE
fix: header for normalize XPNSL

### DIFF
--- a/src/norm.cpp
+++ b/src/norm.cpp
@@ -1575,8 +1575,11 @@ void normalizeXPEHHDataByBins(string &filename, string &outfilename, int &fileLo
     int numInBin = 0;
 
     getline(fin, header);
-
-    fout << header + "\tnormxpehh\tcrit\n";
+    if (XPNSL){
+        fout << header + "\tnormxpnsl\tcrit\n"; 
+    } else{
+        fout << header + "\tnormxpehh\tcrit\n";  
+    } 
 
     for (int j = 0; j < fileLoci; j++)
     {


### PR DESCRIPTION
Hi @szpiech, 

Thanks for this great piece of software! I realized this small bug in the header of `norm --xpnsl`  that I had to write some shell wrappers to work around and thought it could be handled within the software more clearly. Thanks!